### PR TITLE
Use try instead of lib for Math::BigInt::GMP

### DIFF
--- a/Epochs.pm
+++ b/Epochs.pm
@@ -3,7 +3,7 @@ package Epochs;
 use v5.10;
 use strict;
 use warnings;
-use Math::BigInt lib => 'GMP';
+use Math::BigInt try => 'GMP';
 use Math::BigFloat;
 use Scalar::Util qw(looks_like_number);
 use Time::Moment;


### PR DESCRIPTION
To suppress warnings for those of us too lazy to install the proper library.
