### PR TITLE
Added documentation link to the PowerShelll version of Epochs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ This project was first done with [DateTime](http://p3rl.org/DateTime). Then it w
 See [epochs](https://github.com/oylenshpeegul/epochs) for a similar
 thing in Go.
 
-See [Epoch-elixir](https://github.com/oylenshpeegul/Epochs-elixir) for a similar
+See [Epochs-elixir](https://github.com/oylenshpeegul/Epochs-elixir) for a similar
 thing in Elixir.
+
+See [Epochs-Powershell](https://github.com/oylenshpeegul/Epochs-powershell) for a similar
+thing in Powershell.
 
 See [the Epochs gh-page](http://oylenshpeegul.github.io/Epochs-perl/) for motivation.


### PR DESCRIPTION
Changed the Elixir link to say Epochs-elixir instead of Epoch-elixir.
